### PR TITLE
Async loaders

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -59,8 +59,8 @@ class Pipeline extends Readable {
     })
   }
 
-  parseArgument (arg) {
-    const code = this.loaderRegistry.load(arg, this.context, this.variables, this.basePath)
+  async parseArgument (arg) {
+    const code = await this.loaderRegistry.load(arg, this.context, this.variables, this.basePath)
 
     if (code) {
       return code
@@ -73,8 +73,8 @@ class Pipeline extends Readable {
     return arg
   }
 
-  parseOperation (operation) {
-    let result = this.loaderRegistry.load(operation, this.context, this.variables, this.basePath)
+  async parseOperation (operation) {
+    let result = await this.loaderRegistry.load(operation, this.context, this.variables, this.basePath)
 
     if (!result) {
       throw new Error(`Failed to load operation ${operation.value}`)
@@ -83,15 +83,15 @@ class Pipeline extends Readable {
     return result
   }
 
-  parseStep (step) {
-    const operation = this.parseOperation(step.out(ns.p('operation')))
+  async parseStep (step) {
+    const operation = await this.parseOperation(step.out(ns.p('operation')))
 
     const args = step.out(ns.p('arguments'))
 
     const argsArray = (args.term ? [...args.list()] : []).map(arg => this.parseArgument(arg))
 
-    return Promise.resolve().then(() => {
-      return operation.apply(this.context, argsArray)
+    return Promise.all(argsArray).then(resolved => {
+      return operation.apply(this.context, resolved)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "barnard59-formats": "git+https://github.com/zazuko/barnard59-formats.git#master",
     "expect": "^23.6.0",
     "jest": "^23.6.0",
+    "jest-extended": "^0.11.0",
     "rdf-ext": "^1.1.2",
     "standard": "^12.0.1"
   },
@@ -37,6 +38,7 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "lib/**"
-    ]
+    ],
+    "setupTestFrameworkScriptFile": "jest-extended"
   }
 }

--- a/test/definitions/e2e/world-clock-async.ttl
+++ b/test/definitions/e2e/world-clock-async.ttl
@@ -22,7 +22,8 @@
     a ex:DeferredEcmaScript
   ];
   p:arguments ([
-    a ex:PromisedUrl
+    a ex:PromisedUrl ;
+    ex:url "http://worldclockapi.com/api/json/cet/now"
   ]).
 
 <jsonldStructure> a p:Step ;

--- a/test/definitions/e2e/world-clock-async.ttl
+++ b/test/definitions/e2e/world-clock-async.ttl
@@ -1,0 +1,40 @@
+@base <http://example.org/pipeline/> .
+@prefix code: <http://example.org/code/> .
+@prefix ex: <http://example.org/> .
+@prefix p: <http://example.org/barnard59/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<variables> p:variable
+  [
+    p:name "context" ;
+    p:value """{"date\":"http://purl.org/dc/elements/1.1/date"}"""
+  ] .
+
+<> a p:Pipeline ;
+  p:variables <variables> ;
+  p:steps [
+    p:stepList ( <fetch> <jsonldStructure> <serialize> )
+  ] .
+
+<fetch> a p:Step ;
+  p:operation [
+    code:link <node:barnard59-base#fetch.json> ;
+    a ex:DeferredEcmaScript
+  ];
+  p:arguments ([
+    a ex:PromisedUrl
+  ]).
+
+<jsonldStructure> a p:Step ;
+  p:operation [
+    code:link <node:barnard59-base#map> ;
+    a ex:DeferredEcmaScript
+  ];
+  p:arguments ("json => { return { '@context': JSON.parse(this.variables.get('context')), '@id': 'http://worldclockapi.com/api/json/cet/now', date: json.currentDateTime } }"^^code:ecmaScript) .
+
+<serialize> a p:Step ;
+  p:operation [
+    code:link <node:barnard59-base#json.stringify> ;
+    a ex:DeferredEcmaScript
+  ] .
+

--- a/test/pipeline.e2e.test.js
+++ b/test/pipeline.e2e.test.js
@@ -3,6 +3,7 @@ const expect = require('expect')
 const Pipeline = require('../lib/pipelineFactory')
 const load = require('./support/load-pipeline')
 const run = require('../lib/run')
+const asyncLoaders = require('./support/asyncLoaders')
 
 describe('Pipeline', () => {
   test('can load code using node: scheme', async () => {
@@ -18,8 +19,9 @@ describe('Pipeline', () => {
     await run(pipe)
 
     // then
-    expect(out).toContain('date')
-    expect(out).toContain('http://worldclockapi.com/api/json/cet/now')
+    const outJson = JSON.parse(out)
+    expect(outJson).toContainKey('date')
+    expect(outJson).toContainValue('http://worldclockapi.com/api/json/cet/now')
   })
 
   test('can load code using file: scheme', async () => {
@@ -35,7 +37,31 @@ describe('Pipeline', () => {
     await run(pipe)
 
     // then
-    expect(out).toContain('date')
-    expect(out).toContain('http://worldclockapi.com/api/json/cet/now')
+    const outJson = JSON.parse(out)
+    expect(outJson).toContainKey('date')
+    expect(outJson).toContainValue('http://worldclockapi.com/api/json/cet/now')
+  })
+
+  test('can load code using async loaders', async () => {
+    // given
+    const definition = await load('e2e/world-clock-async.ttl')
+    const pipe = Pipeline(definition, {
+      additionalLoaders: [
+        asyncLoaders.promisedUrl,
+        asyncLoaders.promiseWrapper
+      ]
+    })
+    let out = ''
+    pipe.on('data', (chunk) => {
+      out += chunk
+    })
+
+    // when
+    await run(pipe)
+
+    // then
+    const outJson = JSON.parse(out)
+    expect(outJson).toContainKey('@context')
+    expect(outJson).toContainKey('date')
   })
 })

--- a/test/pipeline.e2e.test.js
+++ b/test/pipeline.e2e.test.js
@@ -48,7 +48,7 @@ describe('Pipeline', () => {
     const pipe = Pipeline(definition, {
       additionalLoaders: [
         asyncLoaders.promisedUrl,
-        asyncLoaders.promiseWrapper
+        asyncLoaders.ecmaScriptLoaderWrapper
       ]
     })
     let out = ''

--- a/test/support/asyncLoaders.js
+++ b/test/support/asyncLoaders.js
@@ -1,18 +1,21 @@
+const cf = require('clownface')
+const rdf = require('rdf-ext')
 const ecmaScriptLoader = require('../../lib/loader/ecmaScript')
 
-function promisedUrl () {
-  return Promise.resolve().then(() => 'http://worldclockapi.com/api/json/cet/now')
+function promisedUrl (term, dataset) {
+  const node = cf(dataset).node(term)
+  return Promise.resolve().then(() => node.out(rdf.namedNode('http://example.org/url')).value)
 }
 promisedUrl.register = r => r.registerNodeLoader('http://example.org/PromisedUrl', promisedUrl)
 
-function promiseWrapper () {
+function ecmaScriptLoaderWrapper () {
   const params = arguments
   return Promise.resolve().then(() => ecmaScriptLoader.apply(this, params))
 }
 
-promiseWrapper.register = r => r.registerNodeLoader('http://example.org/DeferredEcmaScript', promiseWrapper)
+ecmaScriptLoaderWrapper.register = r => r.registerNodeLoader('http://example.org/DeferredEcmaScript', ecmaScriptLoaderWrapper)
 
 module.exports = {
   promisedUrl,
-  promiseWrapper
+  ecmaScriptLoaderWrapper
 }

--- a/test/support/asyncLoaders.js
+++ b/test/support/asyncLoaders.js
@@ -1,0 +1,18 @@
+const ecmaScriptLoader = require('../../lib/loader/ecmaScript')
+
+function promisedUrl () {
+  return Promise.resolve().then(() => 'http://worldclockapi.com/api/json/cet/now')
+}
+promisedUrl.register = r => r.registerNodeLoader('http://example.org/PromisedUrl', promisedUrl)
+
+function promiseWrapper () {
+  const params = arguments
+  return Promise.resolve().then(() => ecmaScriptLoader.apply(this, params))
+}
+
+promiseWrapper.register = r => r.registerNodeLoader('http://example.org/DeferredEcmaScript', promiseWrapper)
+
+module.exports = {
+  promisedUrl,
+  promiseWrapper
+}


### PR DESCRIPTION
fixes #12 

Handling promises in pipeline was simple enough.

To test it I added an E2E test as a variation of the world clock examples where steps and parameters are loaded as a promise.