### PR TITLE
Variable loader for more compact definitions

### DIFF
--- a/lib/loader/variable.js
+++ b/lib/loader/variable.js
@@ -1,0 +1,14 @@
+const cf = require('clownface')
+const ns = require('../namespaces')
+
+function loader (term, dataset, { variables }) {
+  const node = cf(dataset).node(term)
+
+  return variables.get(node.out(ns.p('name')).value) || node.out(ns.p('value')).value
+}
+
+loader.register = registry => {
+  registry.registerNodeLoader(ns.p('Variable'), loader)
+}
+
+module.exports = loader

--- a/lib/loader/variable.js
+++ b/lib/loader/variable.js
@@ -4,11 +4,16 @@ const ns = require('../namespaces')
 function loader (term, dataset, { variables }) {
   const node = cf(dataset).node(term)
 
-  return variables.get(node.out(ns.p('name')).value) || node.out(ns.p('value')).value
+  if (term.termType === 'Literal') {
+    return variables.get(term.value)
+  } else {
+    return variables.get(node.out(ns.p('name')).value) || node.out(ns.p('value')).value
+  }
 }
 
 loader.register = registry => {
   registry.registerNodeLoader(ns.p('Variable'), loader)
+  registry.registerLiteralLoader(ns.p('variable'), loader)
 }
 
 module.exports = loader

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -5,6 +5,7 @@ const Pipeline = require('./pipeline')
 const jsLoader = require('./loader/ecmaScript')
 const templateStringLoader = require('./loader/ecmaScriptLiteral')
 const pipelineLoader = require('./loader/pipeline')
+const variableLoader = require('./loader/variable')
 const LoaderRegistry = require('./loader/registry')
 
 function pipelineNode (definition, iri) {
@@ -27,7 +28,8 @@ function create (definition, { iri, basePath, context, objectMode, variables, ad
   const defaultLoaders = [
     jsLoader,
     pipelineLoader,
-    templateStringLoader
+    templateStringLoader,
+    variableLoader
   ]
 
   const loaders = [ ...defaultLoaders, ...additionalLoaders ]

--- a/test/loader/variable.test.js
+++ b/test/loader/variable.test.js
@@ -1,0 +1,47 @@
+/* global describe, test, beforeEach */
+const cf = require('clownface')
+const rdf = require('rdf-ext')
+const expect = require('expect')
+const loader = require('../../lib/loader/variable')
+const ns = require('../../lib/namespaces')
+const namespace = require('@rdfjs/namespace')
+
+describe('variable loader', () => {
+  const example = namespace('http://example.org/pipeline#')
+  let dataset
+  let def
+
+  beforeEach(async () => {
+    dataset = rdf.dataset()
+    def = cf(dataset, rdf.namedNode('http://example.com/'))
+  })
+
+  test('loads variable from the map by name', () => {
+    // given
+    const node = def.node(example('var'))
+    node.addOut(ns.rdf('type'), ns.p('Variable'))
+      .addOut(ns.p('name'), 'foo')
+    const variables = new Map([ [ 'foo', 'bar' ] ])
+
+    // when
+    const result = loader(node, dataset, { variables })
+
+    // then
+    expect(result).toBe('bar')
+  })
+
+  test('loads variable from the node if not present in variable map', () => {
+    // given
+    const node = def.node(example('var'))
+    node.addOut(ns.rdf('type'), ns.p('Variable'))
+      .addOut(ns.p('name'), 'foo')
+      .addOut(ns.p('value'), 'bar')
+    const variables = new Map()
+
+    // when
+    const result = loader(node, dataset, { variables })
+
+    // then
+    expect(result).toBe('bar')
+  })
+})

--- a/test/loader/variable.test.js
+++ b/test/loader/variable.test.js
@@ -44,4 +44,16 @@ describe('variable loader', () => {
     // then
     expect(result).toBe('bar')
   })
+
+  test('loads variable from a string', () => {
+    // given
+    const node = rdf.literal('foo', ns.p('variable'))
+    const variables = new Map([ [ 'foo', 'bar' ] ])
+
+    // when
+    const result = loader(node, dataset, { variables })
+
+    // then
+    expect(result).toBe('bar')
+  })
 })


### PR DESCRIPTION
Fixes #9

This PR adds two enhancements

1. Referencing variables using RDF term

    ```
    <var> a p:Variable ;
      p:name "foo";
      p:value "bar" .
    
    # no variables
    <> a p:Pipeline .
    
    # this will still work all the same
    # the declared value will be used if the it is not otherwise present in the collection
    <step> a p:Step ;
      p:arguments ( <var> ) .
    ```

1. Simpler referencing variables using name

    ```
    <> a p:Pipeline ;
      p:variables [
        p:variable [ p:name "foo"; p:value "bar" . ]
      ] .
    
    # literal, but not a template
    <step> a p:Step ;
      p:arguments ( "foo"^^p:variable ) .
    ```