### PR TITLE
put error cause into stack

### DIFF
--- a/lib/forEach.js
+++ b/lib/forEach.js
@@ -36,7 +36,13 @@ class ForEach extends Transform {
       .catch(err => callback(err))
 
     current.on('data', chunk => this.push(chunk))
-    current.on('error', err => callback(err))
+    current.on('error', cause => {
+      const err = new Error(`error in forEach sub-pipeline ${this.child.node.value}`)
+
+      err.stack += `\nCaused by: ${cause.stack}`
+
+      callback(err)
+    })
   }
 
   runPipeline (chunk, pipeline) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -45,7 +45,7 @@ class Pipeline extends Readable {
         stream.on('error', cause => {
           const err = new Error(`error in pipeline step ${step.value}`)
 
-          err.cause = cause
+          err.stack += `\nCaused by: ${cause.stack}`
 
           this.emit('error', err)
         })
@@ -55,7 +55,6 @@ class Pipeline extends Readable {
 
       lastStream.on('data', chunk => this.push(chunk))
       lastStream.on('end', () => this.push(null))
-      lastStream.on('error', err => this.emit('error', err))
 
       return this
     })


### PR DESCRIPTION
Using the `.cause` property of an error doesn't show nested error causes. This PR attaches the cause to the `.stack` property, which will be shown by `console.error()`. It also adds this feature for forEach sub-pipelines.