### PR TITLE
Log stream

### DIFF
--- a/lib/forEach.js
+++ b/lib/forEach.js
@@ -30,7 +30,7 @@ class ForEach extends Transform {
     const current = this.child.clone({
       ...this.master,
       objectMode: true,
-      logSink: this.log
+      log: this.log
     })
 
     this.runPipeline(chunk, current)

--- a/lib/forEach.js
+++ b/lib/forEach.js
@@ -17,9 +17,10 @@ class ObjectToReadable extends Readable {
 }
 
 class ForEach extends Transform {
-  constructor (pipeline, master, handleChunk) {
+  constructor (pipeline, master, log, handleChunk) {
     super({ objectMode: true })
 
+    this.log = log
     this.child = pipeline
     this.master = master
     this.handleChunk = handleChunk
@@ -28,7 +29,8 @@ class ForEach extends Transform {
   _transform (chunk, encoding, callback) {
     const current = this.child.clone({
       ...this.master,
-      objectMode: true
+      objectMode: true,
+      logSink: this.log
     })
 
     this.runPipeline(chunk, current)
@@ -61,7 +63,7 @@ class ForEach extends Transform {
   }
 
   static create (pipeline, handleChunk) {
-    return new ForEach(pipeline, this.pipeline, handleChunk)
+    return new ForEach(pipeline, this.pipeline, this.log, handleChunk)
   }
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,10 +14,11 @@ class Logger extends Transform {
     }
   }
 
-  writeLog (level, message, details = {}) {
+  writeLog (level, message, { name, ...details } = {}) {
     this.push({
       stack: [this.node],
       level: level.toUpperCase(),
+      name,
       details: details,
       message
     })

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 const Transform = require('readable-stream').Transform
 
-export default class Logger extends Transform {
+class Logger extends Transform {
   constructor (node) {
     super({
       objectMode: true
@@ -31,3 +31,5 @@ export default class Logger extends Transform {
     next()
   }
 }
+
+module.exports = Logger

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,12 +3,15 @@ const Transform = require('readable-stream').Transform
 const levels = [ 'trace', 'debug', 'info', 'warn', 'error', 'fatal' ]
 
 class Logger extends Transform {
-  constructor (node) {
+  constructor (node, { master } = {}) {
     super({
       objectMode: true
     })
 
     this.node = node.term.value
+    if (master) {
+      this.pipe(master)
+    }
   }
 
   writeLog (level, message) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,10 +14,11 @@ class Logger extends Transform {
     }
   }
 
-  writeLog (level, message) {
+  writeLog (level, message, details = {}) {
     this.push({
       stack: [this.node],
       level: level.toUpperCase(),
+      details: details,
       message
     })
   }
@@ -30,8 +31,8 @@ class Logger extends Transform {
 }
 
 levels.forEach((lvl) => {
-  Logger.prototype[lvl] = function (message) {
-    this.writeLog(lvl, message)
+  Logger.prototype[lvl] = function (message, details) {
+    this.writeLog(lvl, message, details)
   }
 })
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,33 @@
+const Transform = require('readable-stream').Transform
+
+export default class Logger extends Transform {
+  constructor (node) {
+    super({
+      objectMode: true
+    })
+
+    this.node = node.term.value
+  }
+
+  debug (message) {
+    this.push({
+      stack: [this.node],
+      level: 'DEBUG',
+      message
+    })
+  }
+
+  info (message) {
+    this.push({
+      stack: [this.node],
+      level: 'INFO',
+      message
+    })
+  }
+
+  _transform (chunk, encoding, next) {
+    chunk.stack.push(this.node)
+    this.push(chunk)
+    next()
+  }
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,7 @@
 const Transform = require('readable-stream').Transform
 
+const levels = [ 'trace', 'debug', 'info', 'warn', 'error', 'fatal' ]
+
 class Logger extends Transform {
   constructor (node) {
     super({
@@ -9,18 +11,10 @@ class Logger extends Transform {
     this.node = node.term.value
   }
 
-  debug (message) {
+  writeLog (level, message) {
     this.push({
       stack: [this.node],
-      level: 'DEBUG',
-      message
-    })
-  }
-
-  info (message) {
-    this.push({
-      stack: [this.node],
-      level: 'INFO',
+      level: level.toUpperCase(),
       message
     })
   }
@@ -31,5 +25,11 @@ class Logger extends Transform {
     next()
   }
 }
+
+levels.forEach((lvl) => {
+  Logger.prototype[lvl] = function (message) {
+    this.writeLog(lvl, message)
+  }
+})
 
 module.exports = Logger

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,10 +16,7 @@ class Pipeline extends Readable {
     this.context.pipeline = this
     this.loaderRegistry = loaderRegistry
 
-    this.context.log = new Logger(this.node)
-    if (context.log) {
-      this.context.log.pipe(context.log)
-    }
+    this.context.log = new Logger(this.node, { master: context.log })
 
     this.init = once(() => this._init().catch(err => this.emit('error', err)))
     this.initVariables = once(async () => {
@@ -108,8 +105,7 @@ class Pipeline extends Readable {
   }
 
   async parseStep (step) {
-    const log = new Logger(step)
-    log.pipe(this.context.log)
+    const log = new Logger(step, { master: this.context.log })
 
     log.info('step init')
     const operation = await this.parseOperation(step.out(ns.code('implementedBy')))

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -107,7 +107,7 @@ class Pipeline extends Readable {
   async parseStep (step) {
     const log = new Logger(step, { master: this.context.log })
 
-    log.info('step init')
+    log.info('step init', { name: 'beforeStepInit' })
     const operation = await this.parseOperation(step.out(ns.code('implementedBy')))
 
     const args = step.out(ns.code('arguments'))
@@ -118,10 +118,10 @@ class Pipeline extends Readable {
       return operation.apply({ ...this.context, log }, resolved)
     }).then(stream => {
       stream.on('finish', () => {
-        log.info('step finished')
+        log.info('step finished', { name: 'afterStep' })
       })
 
-      log.info('step created')
+      log.info('step created', { name: 'afterStepInit' })
 
       return stream
     }).catch(e => this.emit('error', e))

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -4,21 +4,21 @@ const Readable = require('readable-stream').Readable
 const Logger = require('./logger')
 
 class Pipeline extends Readable {
-  constructor (node, { basePath = process.cwd(), context = {}, objectMode, variables = new Map(), loaderRegistry, logSink } = {}) {
+  constructor (node, { basePath = process.cwd(), context = {}, objectMode, variables = new Map(), loaderRegistry } = {}) {
     super({ objectMode })
 
     this.node = node
     this.basePath = basePath
     this.variables = variables
 
-    this.context = context
+    this.context = { ...context }
     this.context.basePath = this.basePath
     this.context.pipeline = this
     this.loaderRegistry = loaderRegistry
 
-    this.log = new Logger(this.node)
-    if (logSink) {
-      this.log.pipe(logSink)
+    this.context.log = new Logger(this.node)
+    if (context.log) {
+      this.context.log.pipe(context.log)
     }
 
     this.init = once(() => this._init().catch(err => this.emit('error', err)))
@@ -45,7 +45,7 @@ class Pipeline extends Readable {
   }
 
   async _init () {
-    this.log.info('initializing pipeline')
+    this.context.log.info('initializing pipeline')
 
     await this.initVariables()
 
@@ -109,7 +109,7 @@ class Pipeline extends Readable {
 
   async parseStep (step) {
     const log = new Logger(step)
-    log.pipe(this.log)
+    log.pipe(this.context.log)
 
     log.info('step init')
     const operation = await this.parseOperation(step.out(ns.code('implementedBy')))

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,9 +1,10 @@
 const ns = require('./namespaces')
 const once = require('lodash/once')
 const Readable = require('readable-stream').Readable
+const Logger = require('./logger')
 
 class Pipeline extends Readable {
-  constructor (node, { basePath = process.cwd(), context = {}, objectMode, variables = new Map(), loaderRegistry } = {}) {
+  constructor (node, { basePath = process.cwd(), context = {}, objectMode, variables = new Map(), loaderRegistry, logSink } = {}) {
     super({ objectMode })
 
     this.node = node
@@ -15,6 +16,11 @@ class Pipeline extends Readable {
     this.context.pipeline = this
     this.loaderRegistry = loaderRegistry
 
+    this.log = new Logger(this.node)
+    if (logSink) {
+      this.log.pipe(logSink)
+    }
+
     this.init = once(() => this._init().catch(err => this.emit('error', err)))
     this.initVariables = once(async () => {
       const parsedVariables = await this.parseVariables()
@@ -23,13 +29,14 @@ class Pipeline extends Readable {
     })
   }
 
-  clone ({ basePath, context, objectMode, variables }) {
+  clone ({ basePath, context, objectMode, variables, logSink }) {
     return new Pipeline(this.node, {
       basePath: basePath || this.basePath,
       context: context || this.context,
       variables: variables || this.variables,
       loaderRegistry: this.loaderRegistry,
-      objectMode: objectMode || this.objectMode
+      objectMode: objectMode || this.objectMode,
+      logSink
     })
   }
 
@@ -38,6 +45,8 @@ class Pipeline extends Readable {
   }
 
   async _init () {
+    this.log.info('initializing pipeline')
+
     await this.initVariables()
 
     await this.initSteps()
@@ -99,7 +108,10 @@ class Pipeline extends Readable {
   }
 
   async parseStep (step) {
-    this.emit('stepInit', step)
+    const log = new Logger(step)
+    log.pipe(this.log)
+
+    log.info('step init')
     const operation = await this.parseOperation(step.out(ns.code('implementedBy')))
 
     const args = step.out(ns.code('arguments'))
@@ -107,16 +119,16 @@ class Pipeline extends Readable {
     const argsArray = (args.term ? [...args.list()] : []).map(arg => this.parseArgument(arg))
 
     return Promise.all(argsArray).then(resolved => {
-      return operation.apply(this.context, resolved)
+      return operation.apply({ ...this.context, log }, resolved)
     }).then(stream => {
       stream.on('finish', () => {
-        this.emit('stepFinish', step)
+        log.info('step finished')
       })
 
-      this.emit('stepCreate', step)
+      log.info('step created')
 
       return stream
-    })
+    }).catch(e => this.emit('error', e))
   }
 
   parseVariables () {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -26,14 +26,14 @@ class Pipeline extends Readable {
     })
   }
 
-  clone ({ basePath, context, objectMode, variables, logSink }) {
+  clone ({ basePath, context, objectMode, variables, log }) {
     return new Pipeline(this.node, {
       basePath: basePath || this.basePath,
       context: context || this.context,
       variables: variables || this.variables,
       loaderRegistry: this.loaderRegistry,
       objectMode: objectMode || this.objectMode,
-      logSink
+      log
     })
   }
 

--- a/test/support/operations/iterateDirectory.js
+++ b/test/support/operations/iterateDirectory.js
@@ -3,15 +3,18 @@ const fs = require('fs')
 const path = require('path')
 
 class FileIterator extends stream.Readable {
-  constructor (dirName, base) {
+  constructor (dirName, base, log) {
     super({
       objectMode: true,
       read: () => {}
     })
 
+    log.debug(`will iterate ${dirName}`)
+
     const directory = path.resolve(base, dirName)
     fs.readdir(directory, (e, files) => {
       files.forEach(file => {
+        log.debug(`pushing file ${file}`)
         this.push(path.resolve(directory, file))
       })
 
@@ -21,7 +24,7 @@ class FileIterator extends stream.Readable {
 }
 
 function iterateFiles (dirName) {
-  return new FileIterator(dirName, this.pipeline.basePath)
+  return new FileIterator(dirName, this.pipeline.basePath, this.log)
 }
 
 module.exports = iterateFiles

--- a/test/support/run.js
+++ b/test/support/run.js
@@ -26,7 +26,7 @@ module.exports = async function (pipe, initialValue = '', appendChunk = null) {
     returnValue = appendChunk(chunk, returnValue)
   })
 
-  pipe.log.on('data', log => {
+  pipe.context.log.on('data', log => {
     console.log(log.level, log.stack[0], log.message, '\n  ', log.stack.slice(1).join(' -> '))
   })
 

--- a/test/support/run.js
+++ b/test/support/run.js
@@ -26,6 +26,10 @@ module.exports = async function (pipe, initialValue = '', appendChunk = null) {
     returnValue = appendChunk(chunk, returnValue)
   })
 
+  pipe.log.on('data', log => {
+    console.log(log.level, log.stack[0], log.message, '\n  ', log.stack.slice(1).join(' -> '))
+  })
+
   await run(pipe)
 
   return returnValue


### PR DESCRIPTION
Here's my attempt at a log stream, which can be easily used to collect logs or events from all pipelines, not just the root. And doing so with minimal hassle:

1. Pipeline gets a `log` property, where one can write and/or emit
1. That `log` is a `Transform` piped from steps and child-pipelines into the parents. Effectively something like

        subPipeline.log.pipe(step.log.pipe(rootPipeline.log))

1. Every time a log is piped, the transformation adds the node to a stack. That way it's always possible to tell exactly where in the execution it originates
1. There only one listener necessary, which would simply be a `Writable` collecting logs and forwarding to stdout, db, graph, whatever.
1. Lastly, there is no other setup necessary and the usage is uniform. Calling `this.log.debug()` for example will be the same at every level, in pipeline or step.