### PR TITLE
added support for arguments as key value pairs

### DIFF
--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -145,14 +145,17 @@ class Pipeline {
       return Promise.all([...args.list()].map(arg => this.parseArgument(arg)))
     }
 
+    // or an object?
+    const argNodes = args.toArray()
+    const promises = argNodes.map((argNode) => this.parseArgument(argNode.out(ns.p.value)))
+    const values = await Promise.all(promises)
+
     // merge all key value pairs into an object
-    const argObject = await args.toArray().reduce(async (p, argNode) => {
-      const argsResolved = await p
+    const argObject = argNodes.reduce((acc, argNode, idx) => {
+      acc[argNode.out(ns.p.name).value] = values[idx]
 
-      argsResolved[argNode.out(ns.p.name).value] = await this.parseArgument(argNode.out(ns.p.value))
-
-      return argsResolved
-    }, Promise.resolve({}))
+      return acc
+    }, {})
 
     return [argObject]
   }

--- a/test/definitions/arguments.ttl
+++ b/test/definitions/arguments.ttl
@@ -1,0 +1,29 @@
+@base <http://example.org/pipeline/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+
+<list> a p:Pipeline, p:ReadableObjectMode;
+  p:steps [
+    p:stepList ([
+      code:implementedBy [ a code:EcmaScript;
+        code:link <file:support/operations/args-to-stream>
+      ];
+      code:arguments ("a" "b")
+    ])
+  ].
+
+<key-values> a p:Pipeline, p:ReadableObjectMode;
+  p:steps [
+    p:stepList ([
+      code:implementedBy [ a code:EcmaScript;
+        code:link <file:support/operations/args-to-stream>
+      ];
+      code:arguments [
+        p:name "a";
+        p:value "1"
+      ], [
+        p:name "b";
+        p:value "2"
+      ]
+    ])
+  ].

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -1,9 +1,11 @@
 /* global describe, test */
 const assert = require('assert')
 const expect = require('expect')
+const path = require('path')
 const Pipeline = require('../lib/pipelineFactory')
 const load = require('./support/load-pipeline')
 const ns = require('./support/namespaces')
+const streamToArray = require('./support/streamToArray')
 
 describe('pipeline', () => {
   describe('constructor', () => {
@@ -100,6 +102,36 @@ describe('pipeline', () => {
       // then
       expect(pipeline.variables.size).toBe(1)
       expect(pipeline.variables.get('foo')).toBe('boar')
+    })
+  })
+
+  describe('steps', () => {
+    describe('arguments', () => {
+      test('should accept arguments as rdf:List', async () => {
+        // given
+        const definition = await load('arguments.ttl')
+        const iri = ns.pipeline('list')
+
+        // when
+        const pipeline = Pipeline(definition, iri, { basePath: path.resolve('test') })
+        const content = await streamToArray(pipeline)
+
+        // then
+        expect(content).toEqual(['a', 'b'])
+      })
+
+      test('should accept arguments as key value pairs', async () => {
+        // given
+        const definition = await load('arguments.ttl')
+        const iri = ns.pipeline('key-values')
+
+        // when
+        const pipeline = Pipeline(definition, iri, { basePath: path.resolve('test') })
+        const content = await streamToArray(pipeline)
+
+        // then
+        expect(content).toEqual([{ a: '1', b: '2' }])
+      })
     })
   })
 })

--- a/test/support/streamToArray.js
+++ b/test/support/streamToArray.js
@@ -1,0 +1,13 @@
+const run = require('../../lib/run')
+
+async function streamToArray (pipeline) {
+  const content = []
+
+  pipeline.on('data', chunk => content.push(chunk))
+
+  await run(pipeline)
+
+  return content
+}
+
+module.exports = streamToArray


### PR DESCRIPTION
This PR adds support for arguments in key value pair style. See the new `arguments.ttl` how the structure looks like.