### PR TITLE
Bind logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,6 +12,12 @@ class Logger extends Transform {
     if (master) {
       this.pipe(master, { end: false })
     }
+
+    levels.forEach((lvl) => {
+      this[lvl] = (message, details) => {
+        this.writeLog(lvl, message, details)
+      }
+    })
   }
 
   writeLog (level, message, { name, ...details } = {}) {
@@ -30,11 +36,5 @@ class Logger extends Transform {
     next()
   }
 }
-
-levels.forEach((lvl) => {
-  Logger.prototype[lvl] = function (message, details) {
-    this.writeLog(lvl, message, details)
-  }
-})
 
 module.exports = Logger

--- a/test/createBaseStream.test.js
+++ b/test/createBaseStream.test.js
@@ -1,4 +1,3 @@
-/* global describe, test */
 const createBaseStream = require('../lib/createBaseStream')
 const createDummyPipeline = require('./support/createDummyPipeline')
 const eventToPromise = require('../lib/eventToPromise')

--- a/test/createPipelineStream.test.js
+++ b/test/createPipelineStream.test.js
@@ -1,4 +1,3 @@
-/* global describe, test */
 const clownface = require('clownface')
 const createLoaderRegistry = require('../lib/createLoaderRegistry')
 const createPipelineStream = require('../lib/createPipelineStream')

--- a/test/forEach.e2e.test.js
+++ b/test/forEach.e2e.test.js
@@ -1,4 +1,3 @@
-/* global describe, test */
 const expect = require('expect')
 const path = require('path')
 const Pipeline = require('../lib/pipelineFactory')

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,4 +1,3 @@
-/* global describe, test */
 const clownface = require('clownface')
 const expect = require('expect')
 const rdf = require('rdf-ext')

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -1,4 +1,3 @@
-/* global describe, test */
 const assert = require('assert')
 const expect = require('expect')
 const Pipeline = require('../lib/pipelineFactory')


### PR DESCRIPTION
(The 1st commit is not related but I didn't want to create a separate PR for such a small detail: [this line](https://github.com/zazuko/barnard59-core/blob/master/.eslintrc.js#L5) already enables jest's globals for test files.)

I had issues with the logger in barnard59-kafka, where the logger wasn't bound to its correct context. This PR solves issues such as:

```
this.consumer.on('data', logger.info)
```

which gave:

```
/myproject/node_modules/barnard59-core/lib/logger.js:42
    this.writeLog(lvl, message, details)
         ^

TypeError: this.writeLog is not a function
    at KafkaConsumerStream.Logger.(anonymous function) (/myproject/node_modules/barnard59-core/lib/logger.js:42:10)
    at KafkaConsumerStream.emit (events.js:194:15)
    at addChunk (_stream_readable.js:284:12)
    at readableAddChunk (_stream_readable.js:265:11)
    at KafkaConsumerStream.Readable.push (_stream_readable.js:220:10)
    at onread (/mylibs/zazuko/barnard59-kafka/node_modules/node-rdkafka/lib/kafka-consumer-stream.js:207:14)
    at /mylibs/zazuko/barnard59-kafka/node_modules/node-rdkafka/lib/kafka-consumer.js:460:7
```

I tried adding a test for this but I couldn't figure it out, I'd appreciate help on this.