### PR TITLE
fix: wait for the last stream in .final handling

### DIFF
--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -132,7 +132,9 @@ class Pipeline {
     }
 
     this.final = (callback) => {
-      this.firstStream.end(callback)
+      finished(this.lastStream, callback)
+
+      this.firstStream.end()
     }
   }
 


### PR DESCRIPTION
This changes the handling of the `.final()` method of the `Writable` interface of a pipeline. Before the callback was called after the first step finished. Now the callback waits for the last step in the pipeline. Since all steps themself have the error handler connected to the pipeline, this caused a race condition if the first step of a writable pipeline finished and an error occurred in a later step. This PR does not contain a test. After the planned code cleanup it should be way easier to mock this setup and write a test for it.