### PR TITLE
fix: subpipeline logs were not present in output

### DIFF
--- a/lib/loader/pipeline.js
+++ b/lib/loader/pipeline.js
@@ -1,9 +1,9 @@
 import createPipeline from '../factory/pipeline.js'
 import ns from '../namespaces.js'
 
-async function loader (ptr, { basePath, context, loaderRegistry, logger, variables } = {}) {
+async function loader (ptr, { basePath, context = {}, loaderRegistry, variables } = {}) {
   if (ptr.has(ns.rdf.type, ns.p.Pipeline).terms.length > 0) {
-    return createPipeline(ptr, { basePath, context, loaderRegistry, logger, variables }).stream
+    return createPipeline(ptr, { basePath, context, loaderRegistry, logger: context.logger, variables }).stream
   }
 
   throw new Error('Unrecognized or missing pipeline type')


### PR DESCRIPTION
Fixes https://github.com/zazuko/barnard59-base/issues/25

I found that every sub pipeline created with the loader get a fresh logger. Instead, the parent's logger should be forwarded from the parent context

Any suggestions for a good test case?