### PR TITLE
Handle step errors which occur before pipeline init

### DIFF
--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -63,6 +63,11 @@ class Pipeline extends StreamObject {
     return this.children[this.children.length - 1]
   }
 
+  addChild (step) {
+    step.stream.on('error', err => this.destroy(err))
+    this.children.push(step)
+  }
+
   async _init () {
     this.logger.debug({ iri: this.ptr.value, message: 'initialize Pipeline' })
 
@@ -76,11 +81,6 @@ class Pipeline extends StreamObject {
       // connect all steps
       for (let index = 0; index < this.children.length - 1; index++) {
         this.children[index].stream.pipe(this.children[index + 1].stream)
-      }
-
-      // add error handler to all steps
-      for (let index = 0; index < this.children.length; index++) {
-        this.children[index].stream.on('error', err => this.destroy(err))
       }
 
       finished(this.lastChild.stream, err => {

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -126,7 +126,7 @@ class Pipeline extends StreamObject {
       }
 
       for (; ;) {
-        if (this.lastChild.stream._readableState.destroyed || this.lastChild.stream._readableState.endEmitted) {
+        if (this.stream._readableState.destroyed || this.lastChild.stream._readableState.destroyed || this.lastChild.stream._readableState.endEmitted) {
           return
         }
 

--- a/lib/factory/pipeline.js
+++ b/lib/factory/pipeline.js
@@ -47,9 +47,9 @@ function createPipeline (ptr, {
 
     for (const stepPtr of ptr.out(ns.p.steps).out(ns.p.stepList).list()) {
       if (stepPtr.has(ns.rdf.type, ns.p.Pipeline).terms.length > 0) {
-        pipeline.children.push(createPipeline(stepPtr, { basePath, context, loaderRegistry, logger, variables }))
+        pipeline.addChild(createPipeline(stepPtr, { basePath, context, loaderRegistry, logger, variables }))
       } else {
-        pipeline.children.push(await createStep(stepPtr, { basePath, context, loaderRegistry, logger, variables }))
+        pipeline.addChild(await createStep(stepPtr, { basePath, context, loaderRegistry, logger, variables }))
       }
     }
   }

--- a/lib/factory/step.js
+++ b/lib/factory/step.js
@@ -21,11 +21,8 @@ async function createStep (ptr, { basePath, context, loaderRegistry, logger, var
       const stream = await operation.apply(context, args)
 
       if (!stream || !isStream(stream)) {
-        throw new Error(`${ptr.value} didn't return a stream`)
+        onError(new Error(`${ptr.value} didn't return a stream`))
       }
-
-      stream.on('error', onError)
-      stream.on('pipe', () => stream.off('error', onError))
 
       return new Step({ args, basePath, context, loaderRegistry, logger, operation, ptr, stream, variables })
     } catch (cause) {

--- a/test/Pipeline.test.js
+++ b/test/Pipeline.test.js
@@ -49,6 +49,16 @@ describe('Pipeline', () => {
     strictEqual(result, 'test')
   })
 
+  it('should emit error when nested pipeline step errors immediately', async () => {
+    const ptr = await loadPipelineDefinition('nestedErrorBeforeInit')
+
+    const pipeline = createPipeline(ptr, { basePath: resolve('test') })
+
+    await rejects(async () => {
+      await getStream(pipeline.stream)
+    })
+  })
+
   it('should support nested writable pipelines', async () => {
     const ptr = await loadPipelineDefinition('nested-write')
     const result = []

--- a/test/support/definitions/nestedErrorBeforeInit.ttl
+++ b/test/support/definitions/nestedErrorBeforeInit.ttl
@@ -1,0 +1,33 @@
+@base <http://example.org/pipeline/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+
+<> a p:Pipeline, p:Readable ;
+    p:steps
+        [
+            p:stepList ( <subPipeline> )
+        ] .
+
+<subPipeline>
+    a p:Pipeline, p:Readable ;
+    p:steps
+        [
+            p:stepList ( <openMissingFile> <forward> )
+        ]
+.
+
+<openMissingFile> a p:Step ;
+    code:implementedBy
+        [
+            a code:EcmaScriptModule ;
+            code:link <node:fs#createReadStream>
+        ] ;
+    code:arguments ( "./no/such/file" ) .
+
+<forward> a p:Step ;
+    code:implementedBy
+        [
+            a code:EcmaScriptModule ;
+            code:link <node:barnard59-base/limit.js#default>
+        ];
+        code:arguments ( 100 ).


### PR DESCRIPTION
fixes #70 

The crucial part of the reproduction was to pipe the failed `createReadStream` through another step (such as would be a parser in SHACL scenario zazuko/barnard59#63). This way the error remains unhandled