### PR TITLE
build(deps): replace isstream with is-stream

### DIFF
--- a/lib/isStream.js
+++ b/lib/isStream.js
@@ -1,13 +1,14 @@
-import isStream from 'isstream'
+import {
+  isReadableStream as isReadable,
+  isWritableStream as isWritable,
+  isDuplexStream as isDuplex
+} from 'is-stream'
 
-const isReadable = isStream.isReadable
 const isReadableObjectMode = stream => isReadable(stream) && stream._readableState.objectMode
-const isWritable = isStream.isWritable
 const isWritableObjectMode = stream => isWritable(stream) && stream._writableState.objectMode
-const isDuplex = isStream.isDuplex
 
+export { isStream } from 'is-stream'
 export {
-  isStream,
   isReadable,
   isReadableObjectMode,
   isWritable,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clownface": "^1.4.0",
     "duplex-to": "^1.0.1",
     "duplexify": "^4.1.1",
-    "isstream": "^0.1.2",
+    "is-stream": "^3.0.0",
     "lodash": "^4.17.21",
     "rdf-ext": "^1.3.2",
     "rdf-loader-code": "^0.3.2",


### PR DESCRIPTION
Fixes an issue I found when trying to use `barnard59-validate-shacl` where `isstream` checks with `obj instance of stram.Stream`

That did not work because the stream in shacl step is imported from `readable-stream`