### PR TITLE
fix: variable without value

### DIFF
--- a/.changeset/lemon-dryers-lie.md
+++ b/.changeset/lemon-dryers-lie.md
@@ -1,0 +1,5 @@
+---
+"barnard59-core": patch
+---
+
+Skip variables without `p:value`

--- a/lib/factory/variables.js
+++ b/lib/factory/variables.js
@@ -16,7 +16,7 @@ async function createVariables (ptr, { basePath, context, loaderRegistry, logger
   return variables
 }
 
-function withValue(variable) {
+function withValue (variable) {
   return !!variable.out(ns.p.value).term
 }
 

--- a/lib/factory/variables.js
+++ b/lib/factory/variables.js
@@ -3,7 +3,7 @@ import ns from '../namespaces.js'
 async function createVariables (ptr, { basePath, context, loaderRegistry, logger }) {
   const variables = new Map()
 
-  for (const variablePtr of ptr.out(ns.p.variable).toArray()) {
+  for (const variablePtr of ptr.out(ns.p.variable).toArray().filter(withValue)) {
     const variable = await loaderRegistry.load(variablePtr, { basePath, context, logger, variables })
 
     if (!variable) {
@@ -14,6 +14,10 @@ async function createVariables (ptr, { basePath, context, loaderRegistry, logger
   }
 
   return variables
+}
+
+function withValue(variable) {
+  return !!variable.out(ns.p.value).term
 }
 
 export default createVariables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "barnard59-core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "barnard59-core",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.1",

--- a/test/support/definitions/variables.ttl
+++ b/test/support/definitions/variables.ttl
@@ -8,6 +8,9 @@
     p:variable [ a p:Variable;
       p:name "foo";
       p:value "bar"
+    ] ;
+    p:variable [ a p:Variable;
+      p:name "bar";
     ]
   ].
 


### PR DESCRIPTION
Needed for https://github.com/zazuko/barnard59/pull/67 to be able to define variables without values only to provide additional annotations

A value may be supplied from the CLI and I think we should also implement #62 to ensure that there is a failure when a variable without a value is used