### PR TITLE
Direct all logs to stderr

### DIFF
--- a/.changeset/brave-fans-shout.md
+++ b/.changeset/brave-fans-shout.md
@@ -1,0 +1,5 @@
+---
+"barnard59-core": patch
+---
+
+Sending logs to standard error so that output quads can be redirected to a file

--- a/lib/defaultLogger.js
+++ b/lib/defaultLogger.js
@@ -8,6 +8,7 @@ function factory({ console = true, errorFilename = null, filename = null, level 
 
   if (console) {
     transports.push(new Console({
+      consoleWarnLevels: ['warn', 'debug', 'log', 'info', 'error'],
       format: format.combine(
         format.colorize(),
         format.simple(),


### PR DESCRIPTION
In pipelines which write to file we typically add a final step which calls `createWriteStream`

Actually, I found surprising that we should not simply have serialization as the final step and redirect the standard output to the desired path. This can work for most scenarios

```shell
npx barnard59 run -v ./pipeline.ttl --pipeline http://example.com > output.nt
```

Currently this does not work with the `-v` flag(s) because winston writes some logs to standard output too and they become part of the resulting file.

This PR ensures that all logs go to stderr and will thus remain in the console when doing a standard redirection